### PR TITLE
Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.github
+Dockerfile

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,58 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    tags:
+      - '*'
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+      #
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)."
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# Use Arch Linux as the base image
+FROM archlinux:latest AS builder
+
+# Install necessary dependencies
+RUN pacman -Syu --noconfirm \
+    base-devel \
+    git \
+    go \
+    libvips \
+    ffmpeg \
+    libheif
+
+# Set the working directory inside the container
+WORKDIR /app
+COPY . .
+
+ENV CGO_ENABLED=1
+RUN go build -o /app/timelinize
+
+FROM archlinux:latest AS final
+
+WORKDIR /app
+
+RUN pacman -Syu --noconfirm \
+    libvips \
+    ffmpeg \
+    libheif
+
+RUN useradd -u 1000 -m -s /bin/bash -d /app timelinize
+RUN mkdir -p /app/.config/timelinize /repo
+RUN chown -R timelinize /app
+RUN chown -R timelinize /repo
+
+COPY --from=builder /app/timelinize /app/timelinize
+
+ENV TIMELINIZE_ADMIN_ADDR="0.0.0.0:12002"
+EXPOSE 12002
+
+VOLUME /app/.config/timelinize
+VOLUME /repo
+USER timelinize
+
+CMD ["/app/timelinize", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,10 @@ WORKDIR /app
 COPY . .
 
 ENV CGO_ENABLED=1
-RUN go build -o /app/timelinize
+RUN go env -w GOCACHE=/go/cache
+RUN go env -w GOMODCACHE=/go/modcache
+RUN --mount=type=cache,target=/go/modcache go mod download
+RUN --mount=type=cache,target=/go/modcache --mount=type=cache,target=/go/cache go build -o /app/timelinize
 
 FROM archlinux:latest AS final
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN chown -R timelinize /repo
 
 COPY --from=builder /app/timelinize /app/timelinize
 
-ENV TIMELINIZE_ADMIN_ADDR="0.0.0.0:12002"
+ENV TLZ_ADMIN_ADDR="0.0.0.0:12002"
 EXPOSE 12002
 
 VOLUME /app/.config/timelinize

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ docker run -p12002:12002 \
 ```
 
 That will run Timelinize on port `12002`, with the data repository mounted at `/path/to/repo` (change it to suite your needs) and the configuration directory mounted at `/path/to/config` (change it).
-When using Docker bind mounts like above, make sure the directories exist on your host machine and that they belong to use UID 1000.
+When using Docker bind mounts like above, make sure the directories exist on your host machine and that they belong to the user ID 1000.
 
 > [!NOTE]
 > Because Timelinize is running inside a Docker container, it won't have access to your host's filesystem. You will need to mount the directories you want to access as volumes, to be able to load data into Timelinize.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ These were captured using a dev repository of mine filled with a subset of my re
 
 ## Download and run
 
+### From release binaries
+
 > [!IMPORTANT]
 > Please ensure [you have the necessary dependencies installed](https://timelinize.com/docs/setup/system-requirements) or Timelinize will not function properly.
 
@@ -61,6 +63,23 @@ After you have the system requirements installed, you can download and run Timel
 
 I recommend running from the command line even if you can double-click to run, so that you can see the log/error output. Logs are also available in your browser dev tools console.
 
+### Using Docker images
+
+> [!NOTE]
+> Docker images are not yet available. This section will be updated when they are.
+
+```
+docker run -p12002:12002 \
+           -v /path/to/repo:/repo \
+           -v /path/to/config:/app/.config/timelinize \
+           ghcr.io/timelinize/timelinize
+```
+
+That will run Timelinize on port `12002`, with the data repository mounted at `/path/to/repo` (change it to suite your needs) and the configuration directory mounted at `/path/to/config` (change it).
+When using Docker bind mounts like above, make sure the directories exist on your host machine and that they belong to use UID 1000.
+
+> [!NOTE]
+> Because Timelinize is running inside a Docker container, it won't have access to your host's filesystem. You will need to mount the directories you want to access as volumes, to be able to load data into Timelinize.
 
 ## Build from source
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -78,7 +78,7 @@ func Main(embeddedWebsite fs.FS) {
 	// start the application server
 	// TODO: customized listen address?
 	// TODO: Use a host like tlz.localhost to serve HTTP/2 over HTTPS... just need to automate the CA and cert... - or maybe a public domain like timelinize.app or timelinize.run or something
-	startedServer, err := app.Serve("")
+	startedServer, err := app.Serve(os.Getenv("TIMELINIZE_ADMIN_ADDR"))
 	if err != nil {
 		timeline.Log.Fatal("could not start server", zap.Error(err))
 	}
@@ -171,7 +171,7 @@ func checkFlagParsing() error {
 var standardCommands = map[string]func() error{
 	"serve": func() error {
 		// TODO: customized listen address?
-		if err := app.MustServe(""); err != nil {
+		if err := app.MustServe(os.Getenv("TIMELINIZE_ADMIN_ADDR")); err != nil {
 			return err
 		}
 		select {}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -78,7 +78,7 @@ func Main(embeddedWebsite fs.FS) {
 	// start the application server
 	// TODO: customized listen address?
 	// TODO: Use a host like tlz.localhost to serve HTTP/2 over HTTPS... just need to automate the CA and cert... - or maybe a public domain like timelinize.app or timelinize.run or something
-	startedServer, err := app.Serve(os.Getenv("TIMELINIZE_ADMIN_ADDR"))
+	startedServer, err := app.Serve(os.Getenv("TLZ_ADMIN_ADDR"))
 	if err != nil {
 		timeline.Log.Fatal("could not start server", zap.Error(err))
 	}
@@ -171,7 +171,7 @@ func checkFlagParsing() error {
 var standardCommands = map[string]func() error{
 	"serve": func() error {
 		// TODO: customized listen address?
-		if err := app.MustServe(os.Getenv("TIMELINIZE_ADMIN_ADDR")); err != nil {
+		if err := app.MustServe(os.Getenv("TLZ_ADMIN_ADDR")); err != nil {
 			return err
 		}
 		select {}

--- a/tlzapp/app.go
+++ b/tlzapp/app.go
@@ -41,6 +41,15 @@ import (
 
 var app *App
 
+func tlzAdminURL() string {
+	tlzAdminAddr := os.Getenv("TLZ_ADMIN_ADDR")
+	if tlzAdminAddr == "" {
+		return "http://localhost:12002"
+	}
+
+	return fmt.Sprintf("http://%s", tlzAdminAddr)
+}
+
 func (a *App) RunCommand(args []string) error {
 	if len(args) == 0 {
 		return errors.New("no command specified")
@@ -244,7 +253,7 @@ func (a *App) serve(adminAddr string) error {
 
 	// set up HTTP client and request with short timeout and context cancellation
 	client := &http.Client{Timeout: 1 * time.Second}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:12002", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, tlzAdminURL(), nil)
 	if err != nil {
 		return err
 	}
@@ -270,7 +279,7 @@ func (a *App) serve(adminAddr string) error {
 
 func (a *App) serverRunning() bool {
 	// TODO: get URL from config?
-	req, err := http.NewRequestWithContext(a.ctx, http.MethodGet, "http://localhost:12002", nil)
+	req, err := http.NewRequestWithContext(a.ctx, http.MethodGet, tlzAdminURL(), nil)
 	if err != nil {
 		return false
 	}

--- a/tlzapp/app.go
+++ b/tlzapp/app.go
@@ -244,7 +244,7 @@ func (a *App) serve(adminAddr string) error {
 
 	// set up HTTP client and request with short timeout and context cancellation
 	client := &http.Client{Timeout: 1 * time.Second}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+adminAddr, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:12002", nil)
 	if err != nil {
 		return err
 	}

--- a/tlzapp/app.go
+++ b/tlzapp/app.go
@@ -41,15 +41,6 @@ import (
 
 var app *App
 
-func tlzAdminURL() string {
-	tlzAdminAddr := os.Getenv("TLZ_ADMIN_ADDR")
-	if tlzAdminAddr == "" {
-		return "http://localhost:12002"
-	}
-
-	return fmt.Sprintf("http://%s", tlzAdminAddr)
-}
-
 func (a *App) RunCommand(args []string) error {
 	if len(args) == 0 {
 		return errors.New("no command specified")
@@ -253,7 +244,7 @@ func (a *App) serve(adminAddr string) error {
 
 	// set up HTTP client and request with short timeout and context cancellation
 	client := &http.Client{Timeout: 1 * time.Second}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, tlzAdminURL(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:12002", nil)
 	if err != nil {
 		return err
 	}
@@ -279,7 +270,7 @@ func (a *App) serve(adminAddr string) error {
 
 func (a *App) serverRunning() bool {
 	// TODO: get URL from config?
-	req, err := http.NewRequestWithContext(a.ctx, http.MethodGet, tlzAdminURL(), nil)
+	req, err := http.NewRequestWithContext(a.ctx, http.MethodGet, "http://localhost:12002", nil)
 	if err != nil {
 		return false
 	}

--- a/tlzapp/server.go
+++ b/tlzapp/server.go
@@ -210,6 +210,7 @@ func (s *server) fillAllowedHosts(listenAddr string) {
 	for _, host := range []string{
 		"localhost",
 		"127.0.0.1",
+		"0.0.0.0",
 		"::1",
 	} {
 		// clients generally omit port if standard, so only expect port if non-standard

--- a/tlzapp/server.go
+++ b/tlzapp/server.go
@@ -210,7 +210,6 @@ func (s *server) fillAllowedHosts(listenAddr string) {
 	for _, host := range []string{
 		"localhost",
 		"127.0.0.1",
-		"0.0.0.0",
 		"::1",
 	} {
 		// clients generally omit port if standard, so only expect port if non-standard


### PR DESCRIPTION
Adds a `Dockerfile` and GitHub workflow files to build and [publish images](https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images) to GitHub Package Registry (ghcr.io).

Notes about the Dockerfile:

* I'm using a multi staged build to reduce the final image size
* Arch Linux Docker base images since @mholt mentioned that's what he uses, and libheif 1.18 is not that common in other stable distribution releases like Fedora, Alpine Linux or Debian
* I've removed the [sed trick](https://github.com/timelinize/timelinize/issues/22#issuecomment-2293739528) from @mbolli from the Dockerfile, since ~~that breaks Docker layer catching~~ causes trouble in health checks. I've opted for a small source patch that should not change runtime behaviour if `TIMELINIZE_ADMIN_ADDR` environment variable isn't defined. The source patch is intented to be a workaround until @mholt decides on command line args or environment variables supported.
* TIMELINIZE_ADMIN_ADDR is used in the Dockerfile to make Timelinize listen on all interfaces by default inside the Docker container
* Timelinize runs as a regular user (`timelinize` with UID 1000) inside the docker container
* Two volumes, `/repo` and `/app/.config/timelinize` are exposed by default, in case you want to keep state between container restarts (i.e. using Timelinize as a service).

Notes about the new GitHub workflow:

* The workflow will build and publish the image on every tag push once merged. It'll be required to make the package public (from https://github.com/orgs/timelinize/packages), before it can be pulled anonymously
* The package/container will be published to the [Timelinize Org](https://github.com/orgs/timelinize/packages) repository by default

Notes about running the container:

* `docker run -p12002:12002 -v /path/to/repo:/repo -v /path/to/config:/app/.config/timelinize ghcr.io/timelinize/timelinize` would typically run the container and use two filesystem mount points to store timelinize state. If it's a bind mount, the directory owner should have a matching UID (1000) to avoid permission issues, which is typically the UID for the first user created in a Linux distribution. For testing purposes, omitting volume flags would work fine.