### PR TITLE
Build on macos-14 also, Intel

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -12,9 +12,13 @@ jobs:
   goreleaser:
     strategy:
       matrix:
-        os: [ubuntu, windows, macos]
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+          - macos-14-large
         go-version: [1.23.x]
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,7 +40,7 @@ jobs:
       # but I haven't looked into using it. We'd have to install the packages using
       # its shell, but I'm not sure how to do that.
       - name: Install MSYS2 (Windows)
-        if: matrix.os == 'windows'
+        if: matrix.os == 'windows-latest'
         uses: msys2/setup-msys2@v2
         with:
           # TODO: Enable this for more current packages, I guess? But it takes longer.
@@ -48,7 +52,7 @@ jobs:
             mingw-w64-x86_64-libheif
 
       - name: Install libraries (Linux)
-        if: matrix.os == 'ubuntu'
+        if: matrix.os == 'ubuntu-latest'
         # install libheif (and dependency libde265) from the PPA which is more
         # current; Ubuntu's is too old, resulting in failed compilation
         run: |
@@ -59,14 +63,16 @@ jobs:
           sudo ldconfig
 
       - name: Install libraries (macOS)
-        if: matrix.os == 'macos'
-        run: brew install libheif vips
+        if: ${{ ( matrix.os == 'macos-latest' ) || ( matrix.os == 'macos-14-large' ) }}
+        run: |
+          brew install python || true # Problem in macOS Intel images https://github.com/actions/runner-images/issues/8500
+          brew install libheif vips
 
       # It is crucial to use our gcc compiler instead of the preinstalled gcc,
       # which has an MSYS2 path at c:\msys64. The MSYS2 we installed is at d:\a.
       # (Setting `CC` env var is not enough! You MUST *prepend* the PATH env var!)
       - name: Update PATH (Windows)
-        if: matrix.os == 'windows'
+        if: matrix.os == 'windows-latest'
         shell: bash
         run: echo "D:\a\_temp\msys64\mingw64\bin" >> $GITHUB_PATH
 
@@ -74,21 +80,26 @@ jobs:
         run: go mod download
 
       - name: Switch to Windows only build
-        if: matrix.os == 'windows'
+        if: matrix.os == 'windows-latest'
         run: |
           sed -i 's/_GOOS_/windows/g' .goreleaser.yml
 
       - name: Switch to Mac OS X only build
-        if: matrix.os == 'macos'
+        if: matrix.os == 'macos-latest'
         run: |
           sed -i.tmp -e 's/_GOOS_/darwin/g' .goreleaser.yml
           # https://github.com/actions/runner-images?tab=readme-ov-file#available-images macos-14 is arm unless large.
           sed -i.tmp -e 's/amd64/arm64/g' .goreleaser.yml
 
+      - name: Switch to Mac OS X only build (x64)
+        if: matrix.os == 'macos-14-large'
+        run: |
+          sed -i.tmp -e 's/_GOOS_/darwin/g' .goreleaser.yml
+
       # Installed heif version must match the version requested by go otherwise you get C. errors.
       # As writing jammy (22.04) uses 1.17.6 https://launchpad.net/~strukturag/+archive/ubuntu/libheif
       - name: Downgrade heif on linux to match ppa version & switch to linux only build
-        if: matrix.os == 'ubuntu'
+        if: matrix.os == 'ubuntu-latest'
         run: | 
           go get github.com/strukturag/libheif@v1.17.6
           sed -i 's/_GOOS_/linux/g' .goreleaser.yml

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,7 @@ builds:
     goarch:
       - amd64
 checksum:
-  name_template: '_GOOS_-checksums.txt'
+  name_template: '{{ .Runtime.Goos }}-{{ .Runtime.Goarch }}-checksums.txt'
 archives:
   -
     format_overrides:


### PR DESCRIPTION
Enables macOS Intel builds and releases.

macos-14-large is used because it's a macOS Intel image, according to https://github.com/actions/runner-images?tab=readme-ov-file#available-images

The build has proven to be flaky on macOS Intel images without the hack in https://github.com/timelinize/timelinize/pull/30/files#diff-7be83bb2bf927f774c15a8aaefef2239c923755f8a8137418d10295361ec3f17R68, but should not affect the build, as it's an unrelated Python issue previously reported.