### PR TITLE
geojson: property parsing fixes

### DIFF
--- a/datasources/geojson/geojson.go
+++ b/datasources/geojson/geojson.go
@@ -189,7 +189,7 @@ func (fi *FileImporter) FileImport(ctx context.Context, filenames []string, item
 
 				// use generic properties as metadata
 				meta := timeline.Metadata(feature.Properties)
-				meta.HumanizeKeys()
+				meta = meta.HumanizeKeys()
 
 				// fill in special-case, standardized metadata using
 				// the same keys as with Google Location History
@@ -396,6 +396,8 @@ func (f *feature) extractKnownProperties() error {
 				f.time = time.UnixMilli(int64(sec)) // we don't store more precise than milliseconds
 				delete(f.Properties, propName)
 			}
+		case nil:
+			// having a time property isn't mandatory, ignore
 		default:
 			return fmt.Errorf("unexpected type for time property %s: %T", propName, val)
 		}

--- a/timeline/itemgraph.go
+++ b/timeline/itemgraph.go
@@ -545,16 +545,18 @@ func (Metadata) isEmpty(v any) bool {
 // HumanizeKeys transforms the keys in m to be more human-friendly.
 // For example, it capitlizes the first character and replaces
 // underscores with spaces.
-func (m Metadata) HumanizeKeys() {
+func (m Metadata) HumanizeKeys() map[string]any {
+	nk := map[string]any{}
 	for key, val := range m {
 		if len(key) == 0 {
 			continue
 		}
 		normKey := strings.ToUpper(string(key[0])) + key[1:]
 		normKey = strings.ReplaceAll(normKey, "_", " ")
-		m[normKey] = val
-		delete(m, key)
+		nk[normKey] = val
 	}
+
+	return nk
 }
 
 // MetadataMergePolicy is a type that specifies how to handle


### PR DESCRIPTION
Fixes some small regressions introduced in https://github.com/timelinize/timelinize/commit/bc5c07d706f3b1b907d5c21d4c1fb0088d3c7e33.

* Accept geojson files without a time property: do not return an error if well-know time properties aren't found, which prevents the entire feature from being ingested.
* Random properties aren't stored sometimes: do not modify the map while iterating it, as that can have unpredictable effects according to the spec (`"The iteration order over maps is not specified and is not guaranteed to be the same from one iteration to the next."` via https://go.dev/ref/spec#For_range).