### PR TITLE
Add workflow to run golangci-lint

### DIFF
--- a/.github/workflows/go-linter.yml
+++ b/.github/workflows/go-linter.yml
@@ -1,0 +1,47 @@
+name: lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Install libraries (Linux)
+        # install libheif (and dependency libde265) from the PPA which is more
+        # current; Ubuntu's is too old, resulting in failed compilation
+        run: |
+          sudo add-apt-repository ppa:strukturag/libheif
+          sudo add-apt-repository ppa:strukturag/libde265
+          sudo apt-get update
+          sudo apt-get install -y libheif-dev libvips-dev
+          sudo ldconfig
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: downgrade heif
+        run: |
+          go get github.com/strukturag/libheif@v1.17.6
+          go mod tidy
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -1,0 +1,107 @@
+[linters]
+    enable-all = true
+
+    enable = []
+
+    # We use a blocking approach, enabling all the linters by default and disabling
+    # only the ones we're not interested in.
+    disable = [
+    "exportloopref",
+    "gomoddirectives",
+    "asciicheck",
+    "containedctx",
+    "cyclop",
+    "dogsled",
+    "dupl",
+    "errcheck",
+    "execinquery",
+    "exhaustive",
+    "exhaustruct",
+    "forbidigo",
+    "funlen",
+    "gci",
+    "gochecknoglobals",
+    "gocognit",
+    "goconst",
+    "gocyclo",
+    "godox",
+    "err113",
+    "godot",
+    "gofmt",
+    "gofumpt",
+    "goheader",
+    "gomnd",
+    "mnd",
+    "importas",
+    "inamedparam",
+    "ireturn",
+    "lll",
+    "musttag",
+    "nilnil",
+    "nonamedreturns",
+    "nlreturn",
+    "paralleltest",
+    "perfsprint",
+    "prealloc",
+    "promlinter",
+    "protogetter",
+    "tagliatelle",
+    "testpackage",
+    "thelper",
+    "typecheck",
+    "unparam",
+    "wastedassign",
+    "whitespace",
+    "wrapcheck",
+    "wsl",
+    "varnamelen",
+    ]
+
+
+[run]
+    timeout = "5m"
+    issues-exit-code = 1
+    tests = true
+    build-tags = []
+    skip-dirs = []
+    skip-dirs-use-default = true
+    skip-files = []
+    modules-download-mode = ""
+    allow-parallel-runners = false
+
+
+[output]
+    show-stats = true
+    print-issued-lines = true
+    print-linter-name = true
+    uniq-by-line = true
+    path-prefix = ""
+    sort-results = true
+[[formats]]
+    format = "colored-line-number"
+
+[severity]
+    default-severity = "error"
+    case-sensitive = false
+
+[issues]
+    exclude = []
+
+    max-issues-per-linter = 0
+    max-same-issues = 0
+    exclude-use-default = false
+    include = []
+    new = false
+    fix = false
+
+	[[issues.exclude-rules]]
+        path = "_test.go"
+        linters = ["errcheck", "gosec", "noctx", "bodyclose", "forcetypeassert", "maintidx"]
+
+	[[issues.exclude-rules]]
+        path = "_test.go"
+        linters = ["revive"]
+        text = "unchecked-type-assertion:"
+
+[linters-settings.staticcheck]
+    checks = []


### PR DESCRIPTION
The linter config being added is pretty hardcore, we'll need to tune it to our liking and fix the rest.