### PR TITLE
[WiP] Bump max size of text stored in DB to 50KiB

### DIFF
--- a/timeline/processing.go
+++ b/timeline/processing.go
@@ -1556,4 +1556,4 @@ var sizePeekBufPool = sync.Pool{
 // it's not comfortable to store huge text files in the DB,
 // they belong in files; we just want to avoid lots of little
 // text files on disk.
-const maxTextSizeForDB = 1024 * 1024
+const maxTextSizeForDB = 1024 * 1024 * 50 // 50 KiB


### PR DESCRIPTION
As discussed, 50KiB is a bit more generous and most likely not a problem for sqlite (https://www.sqlite.org/intern-v-extern-blob.html).