### PR TITLE
Test for couldBeMarkdown

### DIFF
--- a/timeline/processor_test.go
+++ b/timeline/processor_test.go
@@ -39,8 +39,8 @@ func TestCouldBeMarkdown(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:	 "HTML",
-			input:	 `<!DOCTYPE html><html lang="en"></html>`,
+			name:     "HTML",
+			input:    `<!DOCTYPE html><html lang="en"></html>`,
 			expected: false,
 		},
 	}

--- a/timeline/processor_test.go
+++ b/timeline/processor_test.go
@@ -1,0 +1,51 @@
+package timeline
+
+import "testing"
+
+func TestCouldBeMarkdown(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "Empty string",
+			input:    "",
+			expected: false,
+		},
+		{
+			name:     "Plain text",
+			input:    "Hello, world!",
+			expected: false,
+		},
+		{
+			name:     "Markdown headers",
+			input:    "# Header 1\n## Header 2",
+			expected: true,
+		},
+		{
+			name:     "Markdown list",
+			input:    "- Item 1\n- Item 2\n- Item 3",
+			expected: true,
+		},
+		{
+			name:     "Markdown link",
+			input:    "[Link text](https://example.com)",
+			expected: true,
+		},
+		{
+			name:     "Markdown code block",
+			input:    "```\ncode block\n```",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := couldBeMarkdown([]byte(tt.input))
+			if result != tt.expected {
+				t.Errorf("couldBeMarkdown(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/timeline/processor_test.go
+++ b/timeline/processor_test.go
@@ -38,6 +38,11 @@ func TestCouldBeMarkdown(t *testing.T) {
 			input:    "```\ncode block\n```",
 			expected: true,
 		},
+		{
+			name:	 "HTML",
+			input:	 `<!DOCTYPE html><html lang="en"></html>`,
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
couldBeMarkdown is greedy, and makes the processing[^1] step set the content type of HTML and plain text files (without extension) as text/markdown.

This has the side effect of excluding text files from in database storage, since that only happens for text/plain files[^2]

[^1]: https://github.com/timelinize/timelinize/blob/8f0f491ad5ee322b1974388c1a584e49c060f8c5/timeline/processing.go#L1479
[^2]: https://github.com/timelinize/timelinize/pull/45#issuecomment-2325018564