### PR TITLE
Out-of-tree data sources support

### DIFF
--- a/.datasources
+++ b/.datasources
@@ -1,0 +1,49 @@
+// This file configures which data sources a binary will be built with.
+//
+// Each uncommented line should contain a single data source package.
+// Line comments starting with // (like this one) are ignored by the generator.
+//
+// An example of an external data source can be found at:
+//
+//    https://github.com/rubiojr/tlz-demo-ds
+//
+// To extend Timelinize and include that data source in your build, add a new line at the
+// bottom of this file.
+//
+// It's also possible to copy this file to a .localds and that data source
+// definition file will take precedence.
+//
+// Then run `go generate && go mod tidy` to regenerate the sources.
+//
+// Default data sources:
+//
+
+contactlist
+email
+facebook
+generic
+geojson
+gmail
+googlelocation
+googlephotos
+gpx
+icloud
+imessage
+instagram
+iphone
+kmlgx
+media
+nmea
+smsbackuprestore
+strava
+telegram
+twitter
+vcard
+
+//
+// Extra data sources, feel free to add them:
+//
+// (comments at the begining of the line should be removed)
+//
+// github.com/rubiojr/tlz-demo-ds
+//

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 _gitignore/
 _storage/
 dist/
+.localds

--- a/datasources.go
+++ b/datasources.go
@@ -1,0 +1,27 @@
+//go:generate go run generator.go
+
+package main
+
+import (
+	_ "github.com/timelinize/timelinize/datasources/contactlist"
+	_ "github.com/timelinize/timelinize/datasources/email"
+	_ "github.com/timelinize/timelinize/datasources/facebook"
+	_ "github.com/timelinize/timelinize/datasources/generic"
+	_ "github.com/timelinize/timelinize/datasources/geojson"
+	_ "github.com/timelinize/timelinize/datasources/gmail"
+	_ "github.com/timelinize/timelinize/datasources/googlelocation"
+	_ "github.com/timelinize/timelinize/datasources/googlephotos"
+	_ "github.com/timelinize/timelinize/datasources/gpx"
+	_ "github.com/timelinize/timelinize/datasources/icloud"
+	_ "github.com/timelinize/timelinize/datasources/imessage"
+	_ "github.com/timelinize/timelinize/datasources/instagram"
+	_ "github.com/timelinize/timelinize/datasources/iphone"
+	_ "github.com/timelinize/timelinize/datasources/kmlgx"
+	_ "github.com/timelinize/timelinize/datasources/media"
+	_ "github.com/timelinize/timelinize/datasources/nmea"
+	_ "github.com/timelinize/timelinize/datasources/smsbackuprestore"
+	_ "github.com/timelinize/timelinize/datasources/strava"
+	_ "github.com/timelinize/timelinize/datasources/telegram"
+	_ "github.com/timelinize/timelinize/datasources/twitter"
+	_ "github.com/timelinize/timelinize/datasources/vcard"
+)

--- a/generator.go
+++ b/generator.go
@@ -1,5 +1,5 @@
 //go:build generator
-// +build generator
+
 package main
 
 import (

--- a/generator.go
+++ b/generator.go
@@ -1,0 +1,78 @@
+//go:build generator
+// +build generator
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/dave/jennifer/jen"
+)
+
+func main() {
+	source := jen.NewFile("main")
+	source.HeaderComment("//go:generate go run generator.go")
+
+	list := datasources()
+	if len(list) == 0 {
+		return
+	}
+
+	for _, ds := range list {
+		source.Anon(ds)
+	}
+
+	f, err := os.Create("datasources.go")
+	if err != nil {
+		genFailed(err)
+	}
+	defer f.Close()
+
+	fmt.Fprintf(f, "%#v", source)
+}
+
+func datasources() []string {
+	var datasources []string
+
+	dsFile := ".localds"
+	if _, err := os.Stat(dsFile); os.IsNotExist(err) {
+		dsFile = ".datasources"
+	}
+
+	f, err := os.Open(dsFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			fmt.Fprintf(os.Stderr, "** no .datasources file found\n")
+			return datasources
+		}
+		genFailed(err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Split(bufio.ScanLines)
+
+	for scanner.Scan() {
+		ds := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(ds, "//") || ds == "" {
+			continue
+		}
+
+		// local data sources
+		if !strings.Contains(ds, "/") {
+			ds = "github.com/timelinize/timelinize/datasources/" + ds
+		}
+
+		datasources = append(datasources, ds)
+	}
+
+	return datasources
+}
+
+func genFailed(err error) {
+	fmt.Fprintf(os.Stderr, "generating datasources.go failed: %s", err)
+	os.Exit(1)
+}

--- a/generator.go
+++ b/generator.go
@@ -1,5 +1,21 @@
 //go:build generator
+/*
+	Timelinize
+	Copyright (c) 2024 Sergio Rubio
 
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published
+	by the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
 package main
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/adrianmo/go-nmea v1.10.0
 	github.com/brianvoe/gofakeit/v6 v6.28.0
 	github.com/caddyserver/caddy/v2 v2.8.4
+	github.com/dave/jennifer v1.7.0
 	github.com/davidbyttow/govips/v2 v2.15.0
 	github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8
 	github.com/galdor/go-thumbhash v1.0.1-0.20240227061205-5f40e920ff45

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
+github.com/dave/jennifer v1.7.0 h1:uRbSBH9UTS64yXbh4FrMHfgfY762RD+C7bUPKODpSJE=
+github.com/dave/jennifer v1.7.0/go.mod h1:nXbxhEmQfOZhWml3D1cDK5M1FLnMSozpbFN/m3RmGZc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/main.go
+++ b/main.go
@@ -22,26 +22,6 @@ import (
 	"embed"
 
 	tlcmd "github.com/timelinize/timelinize/cmd"
-	// plug in data sources
-	_ "github.com/timelinize/timelinize/datasources/contactlist"
-	_ "github.com/timelinize/timelinize/datasources/email"
-	_ "github.com/timelinize/timelinize/datasources/facebook"
-	_ "github.com/timelinize/timelinize/datasources/generic"
-	_ "github.com/timelinize/timelinize/datasources/geojson"
-	_ "github.com/timelinize/timelinize/datasources/googlelocation"
-	_ "github.com/timelinize/timelinize/datasources/googlephotos"
-	_ "github.com/timelinize/timelinize/datasources/gpx"
-	_ "github.com/timelinize/timelinize/datasources/icloud"
-	_ "github.com/timelinize/timelinize/datasources/instagram"
-	_ "github.com/timelinize/timelinize/datasources/iphone"
-	_ "github.com/timelinize/timelinize/datasources/kmlgx"
-	_ "github.com/timelinize/timelinize/datasources/media"
-	_ "github.com/timelinize/timelinize/datasources/nmea"
-	_ "github.com/timelinize/timelinize/datasources/smsbackuprestore"
-	_ "github.com/timelinize/timelinize/datasources/strava"
-	_ "github.com/timelinize/timelinize/datasources/telegram"
-	_ "github.com/timelinize/timelinize/datasources/twitter"
-	_ "github.com/timelinize/timelinize/datasources/vcard"
 )
 
 // Package main is the entry point of the application.


### PR DESCRIPTION
This replaces the current way to load build time data sources, adding support for out of tree data sources available elsewhere, without changing the source tree.

In-tree data sources are now defined in `.datasources`.

If custom, out-of-tree data sources need to be added, `.datasources` can be copied to `.localds` and that will take precedence.

When .datasources or .localds changes:

`go generate && go mod tidy && go build`