### PR TITLE
chore: clean gitub ds leftovers

### DIFF
--- a/datasources/github/github.go
+++ b/datasources/github/github.go
@@ -73,9 +73,8 @@ import (
 type tlzTestKey int
 
 const (
-	DataSourceName            = "GitHub"
-	DataSourceID              = "github"
-	TLZTest        tlzTestKey = iota
+	DataSourceName = "GitHub"
+	DataSourceID   = "github"
 )
 
 type Repository struct {

--- a/datasources/github/github_test.go
+++ b/datasources/github/github_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestClientWalk(t *testing.T) {
 	client := &GitHub{}
-	ctx := context.WithValue(context.Background(), TLZTest, true)
+	ctx := context.Background()
 	opts := timeline.ListingOptions{}
 
 	t.Run("ghstars.json with one starred repo", func(t *testing.T) {


### PR DESCRIPTION
Missed this in https://github.com/timelinize/timelinize/pull/48 after refactoring the code.