### PR TITLE
`~/.local/bin` isn't part of PATH in environ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,5 +42,6 @@ EXPOSE 12002
 VOLUME /app/.config/timelinize
 VOLUME /repo
 USER timelinize
+ENV PATH="$PATH:/app/.local/bin/"
 
 CMD ["/app/timelinize", "serve"]


### PR DESCRIPTION
This fixes this:
```
arran@arran-desktop:/home/arran/Documents/docker/timelinize 33901 
% docker compose up  
[+] Building 286.1s (20/20) FINISHED                                                                                                                                                               docker:default
 => [timelinize internal] load build definition from Dockerfile                                                                                                                                              0.1s
 => => transferring dockerfile: 1.04kB                                                                                                                                                                       0.0s
 => [timelinize internal] load metadata for docker.io/library/archlinux:latest                                                                                                                               3.0s
 => [timelinize internal] load .dockerignore                                                                                                                                                                 0.0s
 => => transferring context: 64B                                                                                                                                                                             0.0s
 => [timelinize internal] load build context                                                                                                                                                                 0.4s
 => => transferring context: 13.01MB                                                                                                                                                                         0.1s
 => [timelinize builder 1/8] FROM docker.io/library/archlinux:latest@sha256:5906892165fc79b4e282e36f24802528bcee2bd2896982ad771045341e15db5c                                                                 0.4s
 => => resolve docker.io/library/archlinux:latest@sha256:5906892165fc79b4e282e36f24802528bcee2bd2896982ad771045341e15db5c                                                                                    0.1s
 => => sha256:5906892165fc79b4e282e36f24802528bcee2bd2896982ad771045341e15db5c 1.23kB / 1.23kB                                                                                                               0.0s
 => => sha256:0ad2f00a305657ced5001f8d41d3dfd6429a8069e4bb3eab890dc232537719ae 1.22kB / 1.22kB                                                                                                               0.0s
 => => sha256:8964901e692515f9bdd5bb6d16e6cb3af6739a6fc6afb3ef299f42411b15a85b 4.06kB / 4.06kB                                                                                                               0.0s
 => [timelinize builder 2/8] RUN pacman -Syu --noconfirm     base-devel     git     go     libvips     ffmpeg     libheif                                                                                  105.2s
 => [timelinize final 2/8] WORKDIR /app                                                                                                                                                                      0.2s
 => [timelinize final 3/8] RUN pacman -Syu --noconfirm     libvips     ffmpeg     libheif                                                                                                                   82.7s
 => [timelinize final 4/8] RUN useradd -u 1000 -m -s /bin/bash -d /app timelinize                                                                                                                            0.5s
 => [timelinize final 5/8] RUN mkdir -p /app/.config/timelinize /repo                                                                                                                                        0.4s
 => [timelinize final 6/8] RUN chown -R timelinize /app                                                                                                                                                      0.4s
 => [timelinize final 7/8] RUN chown -R timelinize /repo                                                                                                                                                     0.4s
 => [timelinize builder 3/8] WORKDIR /app                                                                                                                                                                    0.3s 
 => [timelinize builder 4/8] COPY . .                                                                                                                                                                        0.1s 
 => [timelinize builder 5/8] RUN go env -w GOCACHE=/go/cache                                                                                                                                                 0.4s 
 => [timelinize builder 6/8] RUN go env -w GOMODCACHE=/go/modcache                                                                                                                                           0.6s 
 => [timelinize builder 7/8] RUN --mount=type=cache,target=/go/modcache go mod download                                                                                                                    132.4s 
 => [timelinize builder 8/8] RUN --mount=type=cache,target=/go/modcache --mount=type=cache,target=/go/cache go build -o /app/timelinize                                                                     39.3s 
 => [timelinize final 8/8] COPY --from=builder /app/timelinize /app/timelinize                                                                                                                               0.3s 
 => [timelinize] exporting to image                                                                                                                                                                          3.5s 
 => => exporting layers                                                                                                                                                                                      3.4s
 => => writing image sha256:87e7694ff70ae76e4b8bbf0e0b3e4367b59c5359afaaa53f3de77c55bf29a4d0                                                                                                                 0.0s
 => => naming to docker.io/library/timelinize-timelinize                                                                                                                                                     0.0s
[+] Running 2/2
 ✔ Network timelinize_default         Created                                                                                                                                                                0.1s 
 ✔ Container timelinize-timelinize-1  Created                                                                                                                                                                0.6s 
Attaching to timelinize-1
timelinize-1  | downloading uv 0.5.9 x86_64-unknown-linux-gnu
timelinize-1  | no checksums to verify
timelinize-1  | installing to /app/.local/bin
timelinize-1  |   uv
timelinize-1  |   uvx
timelinize-1  | everything's installed!
timelinize-1  | 
timelinize-1  | To add $HOME/.local/bin to your PATH, either restart your shell or run:
timelinize-1  | 
timelinize-1  |     source $HOME/.local/bin/env (sh, bash, zsh)
timelinize-1  |     source $HOME/.local/bin/env.fish (fish)
timelinize-1  | 2024/12/16 02:52:07.555 FATAL   subcommand failed       {"subcommand": "serve", "error": "starting ML server: exec: \"uv\": executable file not found in $PATH"}
timelinize-1 exited with code 1
```

But turns it into this:
```
arran@arran-desktop:/home/arran/Documents/docker/timelinize 33904 
% docker compose up --build
[+] Building 3.2s (20/20) FINISHED                                                                                                                                                                 docker:default
 => [timelinize internal] load build definition from Dockerfile                                                                                                                                              0.0s
 => => transferring dockerfile: 1.08kB                                                                                                                                                                       0.0s
 => [timelinize internal] load metadata for docker.io/library/archlinux:latest                                                                                                                               2.9s
 => [timelinize internal] load .dockerignore                                                                                                                                                                 0.0s
 => => transferring context: 64B                                                                                                                                                                             0.0s
 => [timelinize internal] load build context                                                                                                                                                                 0.1s
 => => transferring context: 17.70kB                                                                                                                                                                         0.0s
 => [timelinize builder 1/8] FROM docker.io/library/archlinux:latest@sha256:5906892165fc79b4e282e36f24802528bcee2bd2896982ad771045341e15db5c                                                                 0.0s
 => CACHED [timelinize final 2/8] WORKDIR /app                                                                                                                                                               0.0s
 => CACHED [timelinize final 3/8] RUN pacman -Syu --noconfirm     libvips     ffmpeg     libheif                                                                                                             0.0s
 => CACHED [timelinize final 4/8] RUN useradd -u 1000 -m -s /bin/bash -d /app timelinize                                                                                                                     0.0s
 => CACHED [timelinize final 5/8] RUN mkdir -p /app/.config/timelinize /repo                                                                                                                                 0.0s
 => CACHED [timelinize final 6/8] RUN chown -R timelinize /app                                                                                                                                               0.0s
 => CACHED [timelinize final 7/8] RUN chown -R timelinize /repo                                                                                                                                              0.0s
 => CACHED [timelinize builder 2/8] RUN pacman -Syu --noconfirm     base-devel     git     go     libvips     ffmpeg     libheif                                                                             0.0s
 => CACHED [timelinize builder 3/8] WORKDIR /app                                                                                                                                                             0.0s
 => CACHED [timelinize builder 4/8] COPY . .                                                                                                                                                                 0.0s
 => CACHED [timelinize builder 5/8] RUN go env -w GOCACHE=/go/cache                                                                                                                                          0.0s
 => CACHED [timelinize builder 6/8] RUN go env -w GOMODCACHE=/go/modcache                                                                                                                                    0.0s
 => CACHED [timelinize builder 7/8] RUN --mount=type=cache,target=/go/modcache go mod download                                                                                                               0.0s
 => CACHED [timelinize builder 8/8] RUN --mount=type=cache,target=/go/modcache --mount=type=cache,target=/go/cache go build -o /app/timelinize                                                               0.0s
 => CACHED [timelinize final 8/8] COPY --from=builder /app/timelinize /app/timelinize                                                                                                                        0.0s
 => [timelinize] exporting to image                                                                                                                                                                          0.0s
 => => exporting layers                                                                                                                                                                                      0.0s
 => => writing image sha256:28cc55c5fc55a3b8a30eb3eca4e50c3bd4d17145211b59d9af145fac86cc0c69                                                                                                                 0.0s
 => => naming to docker.io/library/timelinize-timelinize                                                                                                                                                     0.0s
[+] Running 1/1
 ✔ Container timelinize-timelinize-1  Recreated                                                                                                                                                              0.2s 
Attaching to timelinize-1
timelinize-1  | downloading uv 0.5.9 x86_64-unknown-linux-gnu
timelinize-1  | no checksums to verify
timelinize-1  | installing to /app/.local/bin
timelinize-1  |   uv
timelinize-1  |   uvx
timelinize-1  | everything's installed!
timelinize-1  | 2024/12/16 02:53:16.132 FATAL   subcommand failed       {"subcommand": "serve", "error": "starting ML server: chdir ml: no such file or directory"}
timelinize-1 exited with code 1
```

Which is set by:

https://github.com/timelinize/timelinize/blob/cbaa39b1b98c110b90301f3af5de5f05edc7d8cc/tlzapp/app.go#L225

I feel that might need to be:

```
func getMLDir() (string, error) {
	// Step 1: Check ML_DIR environment variable
	mlDir := os.Getenv("ML_DIR")
	if mlDir != "" {
		if _, err := os.Stat(mlDir); err == nil {
			return mlDir, nil
		}
	}

	// Step 2: Check "ml" in the current working directory
	cwd, err := os.Getwd()
	if err == nil {
		defaultMLDir := filepath.Join(cwd, "ml")
		if _, err := os.Stat(defaultMLDir); err == nil {
			return defaultMLDir, nil
		}
	}

	// Step 3: Check the HOME directory
	homeDir, err := os.UserHomeDir()
	if err == nil {
		homeMLDir := filepath.Join(homeDir, "ml")
		if _, err := os.Stat(homeMLDir); err == nil {
			return homeMLDir, nil
		}
	}

	// Step 4: Return an error if no valid directory is found
	return "", fmt.Errorf(`"ML" directory does not exist. Please:
1. Specify it using ML_DIR environment variable,
2. Create "ml" in the current working directory, or
3. Create "ml" in your home directory.`)
}


func startMLServer() error {
	// TODO: This has to be distributable somehow; maybe embed it into the binary and then write it to an application dir or something
	cmd := exec.Command("uv", "run", "server.py")

	mlDir, err := getMLDir()
	if err != nil {
		return fmt.Errorf("start ml server: %w", err)
	}
	cmd.Dir = mlDir
	cmd.Stdout = os.Stdout
	cmd.Stderr = os.Stderr
	// TODO: a way to manage the process (stop it, etc)...
	return cmd.Start()
}
```

But I don't know what's going on there. 

The docker container should really be pulling down the ML stuff, unless it needs to update much more frequently than the service is restarted.