### PR TITLE
lint: disable tenv linter, obsolete

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -58,7 +58,7 @@
         "unconvert",
         "unparam",
         "unused",
-	"usetesting",
+        "usetesting",
         "usestdlibvars",
         "wastedassign",
         "whitespace",

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -103,7 +103,6 @@
 
     [linters-settings.depguard.rules.Main]
     files = ["$all", "!$test"]
-    listMode = "Strict"
     allow = [
         "$gostd",
 	    "github.com/dhowden/tag",
@@ -135,7 +134,6 @@
 
     [linters-settings.depguard.rules.Tests]
     files = ["$test"]
-    listMode = "Lax"
 
         # this has to be a list of objects to prevent golangci-lint from panicking (
         [[linters-settings.depguard.rules.Tests.deny]]

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -55,7 +55,6 @@
         "staticcheck",
         "stylecheck",
         "tagalign",
-        "tenv",
         "unconvert",
         "unparam",
         "unused",

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -58,6 +58,7 @@
         "unconvert",
         "unparam",
         "unused",
+	"usetesting",
         "usestdlibvars",
         "wastedassign",
         "whitespace",


### PR DESCRIPTION
Fixing a warning issued by golangci-lint:

WARN The linter 'tenv' is deprecated (since v1.64.0) due to: Duplicate feature another linter. Replaced by usetesting.