### PR TITLE
firefox: check sqlite database has the required table

### DIFF
--- a/datasources/firefox/firefox.go
+++ b/datasources/firefox/firefox.go
@@ -23,6 +23,7 @@ package firefox
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -169,7 +170,7 @@ func checkTables(src string) (bool, error) {
 
 	var exists bool
 	err = db.QueryRow("SELECT 1 FROM sqlite_master WHERE type='table' AND name='moz_places'").Scan(&exists)
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return false, fmt.Errorf("checking table existence: %w", err)
 	}
 	return exists, nil

--- a/datasources/firefox/firefox.go
+++ b/datasources/firefox/firefox.go
@@ -58,7 +58,15 @@ type Firefox struct{}
 // Recognize returns whether the input file is recognized.
 func (Firefox) Recognize(_ context.Context, dirEntry timeline.DirEntry, _ timeline.RecognizeParams) (timeline.Recognition, error) {
 	if filepath.Base(dirEntry.Name()) == "places.sqlite" {
-		return timeline.Recognition{Confidence: 1}, nil
+		var ok bool
+		var err error
+		if ok, err = checkTables(dirEntry.FullPath()); err != nil {
+			return timeline.Recognition{}, fmt.Errorf("checking table existence: %w", err)
+		}
+
+		if ok {
+			return timeline.Recognition{Confidence: 1}, nil
+		}
 	}
 
 	return timeline.Recognition{}, nil
@@ -77,35 +85,8 @@ func (f *Firefox) process(ctx context.Context, path string, itemChan chan<- *tim
 	}
 	defer os.RemoveAll(tempDir)
 
-	tmpDB := filepath.Join(tempDir, filepath.Base(path))
-	// copyFile copies the contents of the source file to the destination file.
-	copyFile := func(src, dst string) error {
-		sourceFile, err := os.Open(src)
-		if err != nil {
-			return fmt.Errorf("opening source file: %w", err)
-		}
-		defer sourceFile.Close()
-
-		destFile, err := os.Create(dst)
-		if err != nil {
-			return fmt.Errorf("creating destination file: %w", err)
-		}
-		defer destFile.Close()
-
-		_, err = io.Copy(destFile, sourceFile)
-		if err != nil {
-			return fmt.Errorf("copying file contents from %s to %s: %w", src, dst, err)
-		}
-
-		return nil
-	}
-	err = copyFile(path, tmpDB)
-	if err != nil {
-		return fmt.Errorf("copying file to temp directory: %w", err)
-	}
-
 	// Open the database in read-only mode
-	db, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?mode=ro", tmpDB))
+	db, err := openDB(path, tempDir)
 	if err != nil {
 		return fmt.Errorf("opening database in read-only mode: %w", err)
 	}
@@ -171,4 +152,53 @@ func (f *Firefox) process(ctx context.Context, path string, itemChan chan<- *tim
 	}
 
 	return nil
+}
+
+func checkTables(src string) (bool, error) {
+	tempDir, err := os.MkdirTemp("", "firefox_import_*")
+	if err != nil {
+		return false, fmt.Errorf("creating temp directory: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	db, err := openDB(src, tempDir)
+	if err != nil {
+		return false, fmt.Errorf("opening database: %w", err)
+	}
+	defer db.Close()
+
+	var exists bool
+	err = db.QueryRow("SELECT 1 FROM sqlite_master WHERE type='table' AND name='moz_places'").Scan(&exists)
+	if err != nil && err != sql.ErrNoRows {
+		return false, fmt.Errorf("checking table existence: %w", err)
+	}
+	return exists, nil
+}
+
+func openDB(src, tempDir string) (*sql.DB, error) {
+	tmpDB := filepath.Join(tempDir, filepath.Base(src))
+	sourceFile, err := os.Open(src)
+	if err != nil {
+		return nil, fmt.Errorf("opening source file: %w", err)
+	}
+	defer sourceFile.Close()
+
+	destFile, err := os.Create(tmpDB)
+	if err != nil {
+		return nil, fmt.Errorf("creating destination file: %w", err)
+	}
+	defer destFile.Close()
+
+	_, err = io.Copy(destFile, sourceFile)
+	if err != nil {
+		return nil, fmt.Errorf("copying file contents from %s to %s: %w", src, tmpDB, err)
+	}
+
+	// Open the database in read-only mode
+	db, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?mode=ro", tmpDB))
+	if err != nil {
+		return nil, fmt.Errorf("opening database in read-only mode: %w", err)
+	}
+
+	return db, nil
 }

--- a/datasources/firefox/firefox_test.go
+++ b/datasources/firefox/firefox_test.go
@@ -23,6 +23,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -118,7 +119,10 @@ func TestFirefox_FileImport(t *testing.T) {
 	defer cancel()
 
 	// Run the import in a goroutine
+	wg := sync.WaitGroup{}
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		f := new(Firefox)
 		dirEntry := timeline.DirEntry{
 			DirEntry: testDirEntry{name: dbFilename},
@@ -166,6 +170,7 @@ func TestFirefox_FileImport(t *testing.T) {
 			t.Fatal("Timeout waiting for imported item")
 		}
 	}
+	wg.Wait()
 
 	if count != 2 {
 		t.Errorf("Expected count 2, got %d", count)

--- a/datasources/firefox/firefox_test.go
+++ b/datasources/firefox/firefox_test.go
@@ -35,11 +35,18 @@ func TestFirefox_Recognize(t *testing.T) {
 		name     string
 		filename string
 		want     float64
+		valid    bool
 	}{
 		{
 			name:     "Places database",
 			filename: "places.sqlite",
 			want:     1,
+			valid:    true,
+		},
+		{
+			name:     "Invalid places database",
+			filename: "places.sqlite",
+			want:     0,
 		},
 		{
 			name:     "Other SQLite file",
@@ -58,8 +65,15 @@ func TestFirefox_Recognize(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			dbPath := filepath.Join(t.TempDir(), tt.filename)
+			_, err := createTestDatabase(dbPath, tt.valid)
+			if err != nil {
+				t.Fatalf("Failed to create test database: %v", err)
+			}
+
 			dirEntry := timeline.DirEntry{
 				DirEntry: testDirEntry{name: tt.filename},
+				FSRoot:   dbPath,
 			}
 
 			recognition, err := f.Recognize(ctx, dirEntry, timeline.RecognizeParams{})
@@ -80,7 +94,7 @@ func TestFirefox_FileImport(t *testing.T) {
 
 	dbFilename := "places.sqlite"
 	dbPath := filepath.Join(tmpDir, dbFilename)
-	db, err := createTestDatabase(dbPath)
+	db, err := createTestDatabase(dbPath, true)
 	if err != nil {
 		t.Fatalf("Failed to create test database: %v", err)
 	}
@@ -167,25 +181,30 @@ func (t testDirEntry) IsDir() bool                { return false }
 func (t testDirEntry) Type() os.FileMode          { return 0 }
 func (t testDirEntry) Info() (os.FileInfo, error) { return nil, nil }
 
-func createTestDatabase(path string) (*sql.DB, error) {
+func createTestDatabase(path string, valid bool) (*sql.DB, error) {
 	db, err := sql.Open("sqlite3", path)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = db.Exec(`
-		CREATE TABLE moz_places (
-			id INTEGER PRIMARY KEY,
-			url TEXT NOT NULL,
-			title TEXT,
-			description TEXT
-		);
-		CREATE TABLE moz_historyvisits (
-			id INTEGER PRIMARY KEY,
-			place_id INTEGER NOT NULL,
-			visit_date INTEGER NOT NULL
-		);
-	`)
+	query := "CREATE TABLE random (id INTEGER PRIMARY KEY);"
+	if valid {
+		query = `
+			CREATE TABLE moz_places (
+				id INTEGER PRIMARY KEY,
+				url TEXT NOT NULL,
+				title TEXT,
+				description TEXT
+			);
+			CREATE TABLE moz_historyvisits (
+				id INTEGER PRIMARY KEY,
+				place_id INTEGER NOT NULL,
+				visit_date INTEGER NOT NULL
+			);
+		`
+	}
+
+	_, err = db.Exec(query)
 	if err != nil {
 		db.Close()
 		return nil, err


### PR DESCRIPTION
This improves Firefox places.sqlite database recognition by making sure it has the required moz_places table we need.

Addresses feedback from https://github.com/timelinize/timelinize/pull/55