### PR TITLE
WhatsApp: fix tests & metadata keys

### DIFF
--- a/datasources/whatsapp/polls.go
+++ b/datasources/whatsapp/polls.go
@@ -23,7 +23,7 @@ func extractPoll(content []string) (string, timeline.Metadata, bool) {
 	}
 
 	meta := make(timeline.Metadata)
-	meta["Poll Question"] = parts[1]
+	meta["Poll question"] = parts[1]
 	customMessage := parts[1]
 
 	for i, optLine := range content[2:] {
@@ -37,8 +37,8 @@ func extractPoll(content []string) (string, timeline.Metadata, bool) {
 		// No need to track error, it's extracted with `\d+`
 		voteCount, _ := strconv.Atoi(parts[2])
 
-		meta[fmt.Sprintf("Poll Option %d", i+1)] = parts[1]
-		meta[fmt.Sprintf("Poll Votes %d", i+1)] = voteCount
+		meta[fmt.Sprintf("Poll option %d", i+1)] = parts[1]
+		meta[fmt.Sprintf("Poll votes %d", i+1)] = voteCount
 	}
 
 	return customMessage, meta, true

--- a/datasources/whatsapp/whatsapp_test.go
+++ b/datasources/whatsapp/whatsapp_test.go
@@ -52,9 +52,9 @@ func TestFileImport(t *testing.T) {
 			metadata: map[string]any{
 				"Poll question": "A question",
 				"Poll option 1": "Option A",
-				"Poll votes 1":  "1",
+				"Poll votes 1":  1,
 				"Poll option 2": "Option B",
-				"Poll votes 2":  "2",
+				"Poll votes 2":  2,
 			}},
 		{owner: "Person 2", index: 12, text: "British Library (96 Euston Rd, London, Greater London NW1 2DB): https://foursquare.com/v/4ac518cef964a52019a620e3",
 			metadata: map[string]any{
@@ -69,19 +69,16 @@ func TestFileImport(t *testing.T) {
 		// Missed voice call omitted
 		// Taken video call omitted
 		// Deleted message omitted
-		{owner: "Person 2", index: 18, text: "An edited message",
-			metadata: map[string]any{
-				"Edited": true,
-			}},
+		{owner: "Person 2", index: 18, text: "An edited message"},
 		{owner: "Persona español", index: 19, text: "Una pregunta\r\n- Opción A (☑︎ 0)\r\n- Opción B (☑︎ 1)\r\n- Opción C (☑︎ 2)",
 			metadata: map[string]any{
 				"Poll question": "Una pregunta",
 				"Poll option 1": "Opción A",
-				"Poll votes 1":  "0",
+				"Poll votes 1":  0,
 				"Poll option 2": "Opción B",
-				"Poll votes 2":  "1",
+				"Poll votes 2":  1,
 				"Poll option 3": "Opción C",
-				"Poll votes 3":  "2",
+				"Poll votes 3":  2,
 			}},
 	}
 
@@ -129,6 +126,16 @@ func TestFileImport(t *testing.T) {
 				}
 
 				validateItemData(t, filename, expFile, attachedItems[j].Content, "incorrect %dth attachment for message %d", j, i)
+			}
+		}
+
+		for key, expectedValue := range expected[i].metadata {
+			if actualValue, ok := message.Item.Metadata[key]; ok {
+				if actualValue != expectedValue {
+					t.Fatalf("metadata value for %s is incorrect, wanted %v (%T), but was %v (%T)", key, expectedValue, expectedValue, actualValue, actualValue)
+				}
+			} else {
+				t.Fatalf("metadata value for %s was missing", key)
 			}
 		}
 


### PR DESCRIPTION
Well this is embarrassing, I forgot to actually test the WhatsApp metadata _and_ the keys emitted weren't correct! Apologies @mholt!

I also realised that I hadn't extracted the `edited` metadata from the messages; I've left that out for now, as I don't think it's as useful as other pieces. (Happy to add it in a subsequent PR if desired though!)