### PR TITLE
Only run CI jobs if the PR is not in draft status

### DIFF
--- a/.github/workflows/go-linter.yml
+++ b/.github/workflows/go-linter.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/go-linter.yml
+++ b/.github/workflows/go-linter.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   golangci:
+    if: github.event.pull_request.draft == false
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
   build:


### PR DESCRIPTION
### Changes

- Skips CI lint and tests if the PR is still in draft status as to not waste CI minutes.