### PR TITLE
Fix opening directory of vCard files

### DIFF
--- a/datasources/vcard/vcard.go
+++ b/datasources/vcard/vcard.go
@@ -91,7 +91,7 @@ func (FileImporter) Recognize(_ context.Context, dirEntry timeline.DirEntry, _ t
 
 // FileImport imports data from the given file/folder.
 func (imp *FileImporter) FileImport(ctx context.Context, dirEntry timeline.DirEntry, params timeline.ImportParams) error {
-	err := fs.WalkDir(dirEntry.FS, dirEntry.Filename, func(_ string, d fs.DirEntry, err error) error {
+	err := fs.WalkDir(dirEntry.FS, dirEntry.Filename, func(filePath string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -109,7 +109,7 @@ func (imp *FileImporter) FileImport(ctx context.Context, dirEntry timeline.DirEn
 			return nil // traverse into subdirectories
 		}
 
-		file, err := dirEntry.Open(".")
+		file, err := dirEntry.FS.Open(filePath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When attempting an import of a zip containing a directory of vCard files or simply a directory of vCard files, errors like the following occur:

```
error read /workspaces/timelinize/iCloud Contacts/iCloud Contacts/Groups: is a directory
```

Modifying the walk function to use the passed path and dirEntry File System resolves this issue.




## Assistance Disclosure

No AI was used.
