### PR TITLE
Fix gallery photo prev/next for photos with time zone

### DIFF
--- a/timeline/search.go
+++ b/timeline/search.go
@@ -592,26 +592,25 @@ func (tl *Timeline) prepareSearchQuery(ctx context.Context, params ItemSearchPar
 		}
 	})
 
-	// TODO: can do local-time-aware querying by doing: "items.timestamp + items.time_offset*1000" instead of just "items.timestamp" (I think)
 	// TODO: Use BETWEEN maybe
 
 	if params.StartTimestamp != nil {
 		and(func() {
-			or("items.timestamp + COALESCE(items.time_offset*1000, 0) "+gt+" ?", params.StartTimestamp.UTC().UnixMilli())
+			or("items.timestamp"+gt+" ?", params.StartTimestamp.UTC().UnixMilli())
 			if !params.StrictStartTimestamp {
 				// if not strict, allow items to spill into the window even if the started before it
-				or("items.timespan + COALESCE(items.time_offset*1000, 0) "+gt+" ?", params.StartTimestamp.UTC().UnixMilli())
+				or("items.timespan "+gt+" ?", params.StartTimestamp.UTC().UnixMilli())
 			}
 		})
 	}
 	if params.EndTimestamp != nil {
 		and(func() {
-			or("items.timestamp + COALESCE(items.time_offset*1000, 0) "+lt+" ?", params.EndTimestamp.UTC().UnixMilli())
+			or("items.timestamp "+lt+" ?", params.EndTimestamp.UTC().UnixMilli())
 		})
 		if params.StrictEndTimestamp {
 			// if strict, items' timespan must end before the EndTimestamp (item can't merely start before it)
 			and(func() {
-				or("items.timespan IS NULL OR items.timespan + COALESCE(items.time_offset*1000, 0) "+lt+" ?", params.EndTimestamp.UTC().UnixMilli())
+				or("items.timespan IS NULL OR items.timespan "+lt+" ?", params.EndTimestamp.UTC().UnixMilli())
 			})
 		}
 	}


### PR DESCRIPTION
When jumping between photos in the gallery with the prev/next button, the buttons were incorrectly enabled/disabled/wouldn't work even if enabled for me. This was caused by the photos having a time zone UTC+1 (time_offset = 3600). The js frontend uses formatted timestamps including the time zone (peekFromItem.timestamp in galleryFilterParams). These are converted to a unix timestamp via UTC().UnixMilli(), so the time zone is already taken care for and adding time_offset is not necessary. For the filtering in the gallery grid itself, a unix timestamp is generated client-side (something like &start=1762124400&end=1762210800) taking the system time zone into account, so this is correct without any extra logic as well.




## Assistance Disclosure

No AI was used.