### PR TITLE
Use @rpath for portable macOS binaries across Intel and Apple Silicon

### DIFF
--- a/.github/scripts/fix-macos-dylib-paths.sh
+++ b/.github/scripts/fix-macos-dylib-paths.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# fix-macos-dylib-paths.sh
+#
+# This script makes macOS binaries portable by converting absolute Homebrew
+# library paths to @rpath-based paths. This allows the same binary to work
+# on both Intel Macs (/usr/local) and Apple Silicon Macs (/opt/homebrew).
+#
+# Usage: ./fix-macos-dylib-paths.sh <binary>
+#
+
+set -e
+
+BINARY="$1"
+
+if [ -z "$BINARY" ]; then
+    echo "Usage: $0 <binary>"
+    exit 1
+fi
+
+if [ ! -f "$BINARY" ]; then
+    echo "Error: Binary not found: $BINARY"
+    exit 1
+fi
+
+echo "Fixing dynamic library paths for: $BINARY"
+
+# Add rpath entries for common Homebrew locations
+# Apple Silicon uses /opt/homebrew, Intel uses /usr/local
+echo "Adding rpath entries..."
+
+# Check if rpath already exists before adding (to avoid errors on re-runs)
+add_rpath_if_missing() {
+    local rpath="$1"
+    if ! otool -l "$BINARY" | grep -A2 "LC_RPATH" | grep -q "$rpath"; then
+        echo "  Adding rpath: $rpath"
+        install_name_tool -add_rpath "$rpath" "$BINARY"
+    else
+        echo "  Rpath already exists: $rpath"
+    fi
+}
+
+add_rpath_if_missing "/opt/homebrew/lib"
+add_rpath_if_missing "/usr/local/lib"
+
+# Also add paths for common Homebrew keg-only formulas that vips depends on
+add_rpath_if_missing "/opt/homebrew/opt/glib/lib"
+add_rpath_if_missing "/usr/local/opt/glib/lib"
+add_rpath_if_missing "/opt/homebrew/opt/vips/lib"
+add_rpath_if_missing "/usr/local/opt/vips/lib"
+add_rpath_if_missing "/opt/homebrew/opt/gettext/lib"
+add_rpath_if_missing "/usr/local/opt/gettext/lib"
+
+# Get all dynamic library dependencies
+echo "Converting absolute paths to @rpath..."
+otool -L "$BINARY" | tail -n +2 | while read -r line; do
+    # Extract the library path (first field before the parentheses)
+    lib_path=$(echo "$line" | awk '{print $1}')
+
+    # Skip system libraries and already-converted paths
+    if [[ "$lib_path" == /System/* ]] || \
+       [[ "$lib_path" == /usr/lib/* ]] || \
+       [[ "$lib_path" == @* ]]; then
+        continue
+    fi
+
+    # Check if this is a Homebrew library path
+    if [[ "$lib_path" == /opt/homebrew/* ]] || [[ "$lib_path" == /usr/local/* ]]; then
+        # Extract just the library filename
+        lib_name=$(basename "$lib_path")
+        new_path="@rpath/$lib_name"
+
+        echo "  $lib_path -> $new_path"
+        install_name_tool -change "$lib_path" "$new_path" "$BINARY"
+    fi
+done
+
+echo "Done! Verifying changes..."
+echo ""
+echo "Updated library paths:"
+otool -L "$BINARY" | grep -v "^$BINARY" | head -20
+
+echo ""
+echo "Rpath entries:"
+otool -l "$BINARY" | grep -A2 "LC_RPATH" | grep "path " || echo "  (none found)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,17 +60,37 @@ jobs:
       # - export CGO_CFLAGS="$(pkg-config --cflags gio-2.0 vips)"
       # - export PKG_CONFIG_PATH="/opt/homebrew/lib/pkgconfig:/opt/homebrew/opt/glib/lib/pkgconfig:$PKG_CONFIG_PATH"
       # but they don't seem to be necessary. Adding as a comment in case something breaks AGAIN in the future, maybe they'll help.
+      #
+      # As of Dec 2025, we also add -rpath flags for both Homebrew locations to make binaries
+      # portable across Intel (/usr/local) and Apple Silicon (/opt/homebrew) Macs.
       - name: Compile application
         env:
           CGO_ENABLED: 1
         shell: bash
         run: |
-          export CGO_LDFLAGS="$(pkg-config --libs gio-2.0 vips)"
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            # Add rpath linker flags for both Homebrew locations for cross-architecture compatibility
+            RPATH_FLAGS="-Wl,-rpath,/opt/homebrew/lib -Wl,-rpath,/usr/local/lib"
+            RPATH_FLAGS="$RPATH_FLAGS -Wl,-rpath,/opt/homebrew/opt/glib/lib -Wl,-rpath,/usr/local/opt/glib/lib"
+            RPATH_FLAGS="$RPATH_FLAGS -Wl,-rpath,/opt/homebrew/opt/vips/lib -Wl,-rpath,/usr/local/opt/vips/lib"
+            RPATH_FLAGS="$RPATH_FLAGS -Wl,-rpath,/opt/homebrew/opt/gettext/lib -Wl,-rpath,/usr/local/opt/gettext/lib"
+            export CGO_LDFLAGS="$(pkg-config --libs gio-2.0 vips) $RPATH_FLAGS"
+          else
+            export CGO_LDFLAGS="${CGO_LDFLAGS:-}"
+          fi
           env
           go env
           echo "Building..."
           go build
           echo "Success."
+
+      # Fix macOS dynamic library paths to use @rpath instead of absolute Homebrew paths
+      # This makes binaries portable across Intel and Apple Silicon Macs
+      - name: Fix dynamic library paths (macOS)
+        if: ${{ matrix.os == 'macos-latest' || matrix.os == 'macos-15-intel' }}
+        run: |
+          chmod +x .github/scripts/fix-macos-dylib-paths.sh
+          ./.github/scripts/fix-macos-dylib-paths.sh ${{ env.APP_NAME }}
       
       # use conventional archive formats for each platform
 

--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,22 @@ dep-libvps:
 
 ### bin
 
+# macOS rpath flags for portable binaries (works on both Intel and Apple Silicon)
+MACOS_RPATH_FLAGS=-Wl,-rpath,/opt/homebrew/lib -Wl,-rpath,/usr/local/lib \
+	-Wl,-rpath,/opt/homebrew/opt/glib/lib -Wl,-rpath,/usr/local/opt/glib/lib \
+	-Wl,-rpath,/opt/homebrew/opt/vips/lib -Wl,-rpath,/usr/local/opt/vips/lib \
+	-Wl,-rpath,/opt/homebrew/opt/gettext/lib -Wl,-rpath,/usr/local/opt/gettext/lib
+
 bin: dep
 	# darwin amd64
 	#CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -o $(BIN_ROOT)/$(BIN_NAME)_darwin_amd64
 	# darwin arm64
+ifeq ($(OS_NAME),darwin)
+	CGO_LDFLAGS="$$(pkg-config --libs gio-2.0 vips) $(MACOS_RPATH_FLAGS)" go build -o $(BIN_ROOT)/$(BIN_NAME)_darwin_arm64
+	./.github/scripts/fix-macos-dylib-paths.sh $(BIN_ROOT)/$(BIN_NAME)_darwin_arm64
+else
 	go build -o $(BIN_ROOT)/$(BIN_NAME)_darwin_arm64
+endif
 bin-cross:
 	# linux amd64
 	#CGO_ENABLED=1 GOOS=linux GOARCH=amd64 CC="zig cc -target x86_64-linux" CXX="zig c++ -target x86_64-linux" go build -o $(BIN_ROOT)/$(BIN_NAME)_linux_amd64


### PR DESCRIPTION
## Problem

The build was embedding absolute Homebrew paths like
/usr/local/opt/vips/lib/libvips.42.dylib, which breaks on Apple Silicon
Macs where Homebrew installs to /opt/homebrew.

## My solution

Adds:
- A post-build script that uses install_name_tool to convert absolute
  paths to @rpath-based paths
- Rpath linker flags for both Homebrew locations during compilation
- Support in both the CI workflow and local Makefile

The resulting binaries work on both Intel and Apple Silicon Macs without
requiring symlinks or environment variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

## Screenshots/demo

Using the downloaded binary vs the one I've built:

<img width="794" height="619" alt="image" src="https://github.com/user-attachments/assets/00c03a41-7d66-467c-beaa-14c20dc9f00b" />

```zsh
137 % ./bin/timelinize
dyld[11499]: Library not loaded: /usr/local/opt/vips/lib/libvips.42.dylib
  Referenced from: <9615CE41-63D5-3E05-EA7F-5EE4BFBF6BBD> /Users/brandon/bin/timelinize
  Reason: tried: '/usr/local/opt/vips/lib/libvips.42.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/opt/vips/lib/libvips.42.dylib' (no such file), '/usr/local/opt/vips/lib/libvips.42.dylib' (no such file)
[1]    11499 abort      ./bin/timelinize
```

## Assistance Disclosure

As indicated above and in the commit itself, I used Claude Code to generate the solution to this problem I was having with the published binaries. The binary that it builds when I run `make` works on my Apple Silicon mac. If there is additional testing that you would like me to do, just ask. 😄 
