### PR TITLE
Pin CI to go 1.25.0 and golangci-lint 2.8.0 exactly

### DIFF
--- a/.github/workflows/go-linter.yml
+++ b/.github/workflows/go-linter.yml
@@ -20,11 +20,12 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
-          check-latest: true
+          go-version: '1.25.0'
 
       - uses: ./.github/actions/compile-libvips-linux
         if: runner.os == 'Linux'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.8.0

--- a/internal/oauth2client/browser.go
+++ b/internal/oauth2client/browser.go
@@ -130,7 +130,7 @@ func openBrowser(ctx context.Context, url string) error {
 
 	buf := new(bytes.Buffer)
 
-	cmd := exec.CommandContext(ctx, exe, append(args, url)...) //nolint:gosec // (all args should be hard-coded or vetted earlier)
+	cmd := exec.CommandContext(ctx, exe, append(args, url)...)
 	cmd.Stdout = buf
 	cmd.Stderr = buf
 	err := cmd.Run()

--- a/timeline/db.go
+++ b/timeline/db.go
@@ -495,7 +495,7 @@ func (tl *Timeline) explainQueryPlan(ctx context.Context, tx *sql.Tx, q string, 
 	fmt.Fprintln(w, argsToDisplay...)
 	fmt.Fprintln(w, "============================================================================================")
 
-	explainQ := "EXPLAIN QUERY PLAN " + q //nolint:gosec
+	explainQ := "EXPLAIN QUERY PLAN " + q
 
 	var rows *sql.Rows
 	var err error


### PR DESCRIPTION
This change pins CI to use go 1.25.0 and golangci-lint to 2.8.0 so that changes outside this repo don't cause CI to break out from under us.

In 01063cf709d63ea1ed0d609dcb1c2504465ad22d, CI passed, and then in 0169e2bd0bb5ab3273366e5e9dbe651e95f596a6, CI began to fail though not due to anything in the commit itself. Every commit since then has failed CI, which drastically devalues CI through [alarm fatigue](https://en.wikipedia.org/wiki/Alarm_fatigue).

The last passing commit's CI [ran with golangci-lint 2.8.0](https://github.com/timelinize/timelinize/actions/runs/21487184099/job/61899566316). The first failing commit [ran with golangci-lint 2.11.4](https://github.com/timelinize/timelinize/actions/runs/23951998278/job/69861473343). 2.11.4 added checks that caused existing issues in the codebase to break CI.

CI should not break out from under us when there have been no changes. We should regularly update to the latest and greatest static analysis tools and linters, but that should happen in a commit where we explicitly choose to upgrade, not automatically during other changes.

I also pinned `go-version` to `1.25.0` instead of `stable` because using go 1.26.0 breaks pinned tooling that expects go 1.25.0.

I also had to partially roll back 9ad4fa1, as golangci-lint fails on unused warning suppressions, and the warnings we suppressed in that commit are for errors that golanci-lint 2.8.0 does not flag.

## Assistance Disclosure

I used AI to find the correct GitHub CI semantics but verified the results.