### PR TITLE
whatsapp: support 2-digit-year date format and locale-less placeholders

### DIFF
--- a/datasources/whatsapp/placeholders.go
+++ b/datasources/whatsapp/placeholders.go
@@ -1,0 +1,50 @@
+package whatsapp
+
+import "strings"
+
+// WhatsApp inserts placeholder text for content it doesn't export as real
+// message data (a deleted message, media omitted from an export without
+// media, etc.). Export variants that include the LRO marker (U+200E) let us
+// drop these generically, since only the text before the first LRO in a
+// message is ever kept (see FileImport). Some export locales (eg. German)
+// omit that marker entirely, so these exact phrases are matched directly as
+// a fallback for those.
+var deletedMessagePlaceholders = []string{
+	"Diese Nachricht wurde gelöscht.", // German: "This message was deleted."
+}
+
+var mediaOmittedPlaceholders = []string{
+	"<Medien ausgeschlossen>", // German: "<Media omitted>"
+}
+
+var editedMessageSuffixes = []string{
+	"<Diese Nachricht wurde bearbeitet.>", // German: "<This message was edited>"
+}
+
+// isPlaceholderOnlyMessage reports whether text is entirely one of
+// WhatsApp's own placeholders rather than user-authored content.
+func isPlaceholderOnlyMessage(text string) bool {
+	for _, p := range deletedMessagePlaceholders {
+		if text == p {
+			return true
+		}
+	}
+	for _, p := range mediaOmittedPlaceholders {
+		if text == p {
+			return true
+		}
+	}
+	return false
+}
+
+// stripEditedSuffix removes a trailing "message was edited" marker that
+// WhatsApp appends to the real message text, returning the text unchanged
+// if no such marker is present.
+func stripEditedSuffix(text string) string {
+	for _, suffix := range editedMessageSuffixes {
+		if trimmed, ok := strings.CutSuffix(text, suffix); ok {
+			return strings.TrimSpace(trimmed)
+		}
+	}
+	return text
+}

--- a/datasources/whatsapp/splitter.go
+++ b/datasources/whatsapp/splitter.go
@@ -8,16 +8,17 @@ import (
 
 var lro = []byte{0xE2, 0x80, 0x8E} // U+200E (LRM)
 const (
-	dateLen    = 10
-	timeLenHM  = 5
-	timeLenHMS = 8
-	splitTwo   = 2
-	minYear    = 1
-	minMonth   = 1
-	maxMonth   = 12
-	minDay     = 1
-	maxDay     = 31
-	scanOffset = 4
+	dateLenShort = 8  // DD?MM?YY
+	dateLenLong  = 10 // DD?MM?YYYY or YYYY?MM?DD
+	timeLenHM    = 5
+	timeLenHMS   = 8
+	splitTwo     = 2
+	minYear      = 1
+	minMonth     = 1
+	maxMonth     = 12
+	minDay       = 1
+	maxDay       = 31
+	scanOffset   = 4
 )
 
 type messageHeader struct {
@@ -75,7 +76,7 @@ func parseMessageHeader(b []byte) (messageHeader, bool) {
 		h.HasLRO = true
 		b = b[len(lro):]
 	}
-	if len(b) < dateLen {
+	if len(b) < dateLenShort {
 		return messageHeader{}, false
 	}
 
@@ -154,9 +155,18 @@ func parseMessageHeader(b []byte) (messageHeader, bool) {
 }
 
 func isDate(b []byte) bool {
-	if len(b) != dateLen {
+	switch len(b) {
+	case dateLenLong:
+		return isDateLongYear(b)
+	case dateLenShort:
+		return isDateShortYear(b)
+	default:
 		return false
 	}
+}
+
+// isDateLongYear checks YYYY?MM?DD or DD?MM?YYYY (4-digit year).
+func isDateLongYear(b []byte) bool {
 	sep4 := b[4]
 	sep2 := b[2]
 
@@ -190,6 +200,26 @@ func isDate(b []byte) bool {
 	}
 
 	return false
+}
+
+// isDateShortYear checks DD?MM?YY (2-digit year), eg. the format used by
+// some WhatsApp export locales: "22.08.18". There's no YY?MM?DD equivalent
+// in the wild, so only the day-first form is checked.
+func isDateShortYear(b []byte) bool {
+	sep := b[2]
+	if sep != '-' && sep != '/' && sep != '.' {
+		return false
+	}
+	if !isDigit(b[0]) || !isDigit(b[1]) ||
+		!isDigit(b[3]) || !isDigit(b[4]) ||
+		!isDigit(b[6]) || !isDigit(b[7]) ||
+		b[5] != sep {
+		return false
+	}
+
+	day, _ := strconv.Atoi(string(b[0:2]))
+	month, _ := strconv.Atoi(string(b[3:5]))
+	return month >= minMonth && month <= maxMonth && day >= minDay && day <= maxDay
 }
 
 func isTime(b []byte) bool {

--- a/datasources/whatsapp/splitter_test.go
+++ b/datasources/whatsapp/splitter_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"testing"
+	"time"
 )
 
 func TestParseMessageHeader(t *testing.T) {
@@ -74,8 +75,22 @@ func TestParseMessageHeader(t *testing.T) {
 			wantLRO:  true,
 		},
 		{
+			name:     "dash DD.MM.YY HH:MM (2-digit year)",
+			line:     "22.08.18, 14:42 - Samuel: Hallo",
+			wantOK:   true,
+			wantDate: "22.08.18",
+			wantTime: "14:42",
+			wantName: "Samuel",
+			wantLen:  len("22.08.18, 14:42 - Samuel: "),
+		},
+		{
 			name:   "invalid date format",
 			line:   "[2024_12_31, 12:34] Bad: nope",
+			wantOK: false,
+		},
+		{
+			name:   "invalid 2-digit-year date (bad month)",
+			line:   "31.13.24, 12:34 - Bad: nope",
 			wantOK: false,
 		},
 		{
@@ -181,6 +196,41 @@ func TestChatSplitSingleMessage(t *testing.T) {
 	}
 	if tokens[0] == "" {
 		t.Fatalf("token should not be empty")
+	}
+}
+
+func TestChatSplitTwoMessagesShortYear(t *testing.T) {
+	tokens := scanTokens(t, "22.08.18, 14:42 - Alice: hello\n22.08.18, 14:43 - Bob: hi there\n")
+	if len(tokens) != 2 {
+		t.Fatalf("expected 2 tokens, got %d", len(tokens))
+	}
+	if tokens[0] != "22.08.18, 14:42 - Alice: hello\n" {
+		t.Fatalf("first token mismatch: got %q", tokens[0])
+	}
+	if tokens[1] != "22.08.18, 14:43 - Bob: hi there\n" {
+		t.Fatalf("second token mismatch: got %q", tokens[1])
+	}
+}
+
+func TestParseTimeShortYear(t *testing.T) {
+	got, err := parseTime("22.08.18", "14:42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := time.Date(2018, time.August, 22, 14, 42, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestParseTimeShortYearPivot(t *testing.T) {
+	// Go's "06" layout token pivots at 68/69: 00-68 -> 2000-2068, 69-99 -> 1969-1999.
+	got, err := parseTime("15.03.99", "08:00")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Year() != 1999 {
+		t.Fatalf("got year %d, want 1999", got.Year())
 	}
 }
 

--- a/datasources/whatsapp/testdata/fixtures-de/_chat.txt
+++ b/datasources/whatsapp/testdata/fixtures-de/_chat.txt
@@ -1,0 +1,6 @@
+22.08.18, 14:42 - Alice: Hallo Bob
+22.08.18, 14:43 - Bob: Hi Alice
+23.08.18, 09:00 - Alice: <Medien ausgeschlossen>
+23.08.18, 09:05 - Bob: Diese Nachricht wurde gelöscht.
+23.08.18, 09:10 - Alice: Testnachricht mit mehreren
+Zeilen <Diese Nachricht wurde bearbeitet.>

--- a/datasources/whatsapp/whatsapp.go
+++ b/datasources/whatsapp/whatsapp.go
@@ -116,7 +116,7 @@ func (i *Importer) FileImport(_ context.Context, dirEntry timeline.DirEntry, par
 		// However, for non-image files, this part of the line often includes the original filename instead, which we don't want to keep
 		var messageText string
 		if attachment == nil {
-			messageText = strings.TrimSpace(content[0])
+			messageText = stripEditedSuffix(strings.TrimSpace(content[0]))
 
 			if pollMessage, pollMeta, isPoll := extractPoll(content); isPoll {
 				messageText = pollMessage
@@ -126,8 +126,10 @@ func (i *Importer) FileImport(_ context.Context, dirEntry timeline.DirEntry, par
 				message.Item.Metadata = locationMeta
 			}
 
-			// Skip messages that have no content & no attachment
-			if messageText == "" {
+			// Skip messages that have no content, no attachment, or are
+			// just a placeholder WhatsApp inserted for content this
+			// export variant doesn't include (eg. a deleted message)
+			if messageText == "" || isPlaceholderOnlyMessage(messageText) {
 				continue
 			}
 
@@ -180,9 +182,17 @@ func parseTime(dateStr, timeStr string) (time.Time, error) {
 		}
 	}
 
+	// Some export locales (eg. German) use a 2-digit year: "22.08.18".
+	// There's no YY-MM-DD equivalent in the wild, so this only applies
+	// when the day comes first.
+	yearToken := "2006"
+	if yearAtEnd && len(dateStr) == dateLenShort {
+		yearToken = "06"
+	}
+
 	var format string
 	if yearAtEnd {
-		format = fmt.Sprintf("02%s01%s2006 15:04:05", sep, sep)
+		format = fmt.Sprintf("02%s01%s%s 15:04:05", sep, sep, yearToken)
 	} else {
 		format = fmt.Sprintf("2006%s01%s02 15:04:05", sep, sep)
 	}

--- a/datasources/whatsapp/whatsapp_test.go
+++ b/datasources/whatsapp/whatsapp_test.go
@@ -147,6 +147,65 @@ func TestFileImport(t *testing.T) {
 	}
 }
 
+// TestFileImportGermanShortYear covers a real-world export variant that
+// differs from the primary fixture in two ways: dates use a 2-digit year
+// ("22.08.18" instead of "2020-01-01"), and the export has no LRO markers at
+// all, so WhatsApp's own placeholders (deleted message, media omitted, the
+// edited-message marker) show up as plain German text instead of being
+// separated out with U+200E.
+func TestFileImportGermanShortYear(t *testing.T) {
+	fixtures := os.DirFS("testdata/fixtures-de")
+	dirEntry := timeline.DirEntry{FS: fixtures}
+
+	pipeline := make(chan *timeline.Graph, 100)
+	params := timeline.ImportParams{Pipeline: pipeline}
+
+	runErr := new(whatsapp.Importer).FileImport(context.Background(), dirEntry, params)
+	if runErr != nil {
+		t.Errorf("unable to import file: %v", runErr)
+	}
+	close(params.Pipeline)
+
+	expected := []struct {
+		owner string
+		year  int
+		month int
+		day   int
+		text  string
+	}{
+		{owner: "Alice", year: 2018, month: 8, day: 22, text: "Hallo Bob"},
+		{owner: "Bob", year: 2018, month: 8, day: 22, text: "Hi Alice"},
+		// <Medien ausgeschlossen> (media omitted) is skipped
+		// "Diese Nachricht wurde gelöscht." (message deleted) is skipped
+		{owner: "Alice", year: 2018, month: 8, day: 23, text: "Testnachricht mit mehreren\nZeilen"},
+	}
+
+	i := 0
+	for message := range pipeline {
+		if i >= len(expected) {
+			t.Fatalf("received more messages than expected, extra message: %+v", message.Item)
+		}
+
+		if message.Item.Owner.Name != expected[i].owner {
+			t.Fatalf("incorrect owner for message %d, wanted %s but was %s", i, expected[i].owner, message.Item.Owner.Name)
+		}
+		if message.Item.Timestamp.Year() != expected[i].year ||
+			int(message.Item.Timestamp.Month()) != expected[i].month ||
+			message.Item.Timestamp.Day() != expected[i].day {
+			t.Fatalf("incorrect date for message %d, wanted %04d-%02d-%02d but was %s",
+				i, expected[i].year, expected[i].month, expected[i].day, message.Item.Timestamp.Format("2006-01-02"))
+		}
+
+		validateItemData(t, "", expected[i].text, message.Item.Content, "incorrect text for message %d", i)
+
+		i++
+	}
+
+	if i != len(expected) {
+		t.Fatalf("received %d messages instead of %d", i, len(expected))
+	}
+}
+
 func validateItemData(t *testing.T, expectedFilename string, expectedData any, itemData timeline.ItemData, errorMessage string, errorArgs ...any) {
 	errMsg := fmt.Sprintf(errorMessage, errorArgs...)
 


### PR DESCRIPTION
## Assistance Disclosure

This PR was written by Claude (Anthropic's AI coding agent) working under my
direction. I provided a real WhatsApp export that failed to import, asked for
root-cause analysis, made the call on scope (the date-format fix is required;
I additionally asked for the placeholder-text cleanup described below), and
verified the result by importing my real ~300-message export into a live
Timelinize instance before opening this PR. I reviewed the diff and reasoning
but did not hand-write the parsing logic myself.

## What

Some WhatsApp export locales (eg. German) use a 2-digit year in the message
header (`22.08.18, 14:42 - Name: ...`) instead of 4 digits. The date/time
parser required exactly 10 characters for the date portion, so none of these
headers were recognized and the entire export silently failed to import.

- `splitter.go`: `isDate()` now accepts both 8-char (`DD?MM?YY`) and 10-char
  (`DD?MM?YYYY` / `YYYY?MM?DD`) date strings.
- `whatsapp.go`: `parseTime()` picks the `06` vs `2006` Go time layout token
  based on the date string length, so 2-digit years resolve through Go's
  standard pivot (00-68 -> 2000s, 69-99 -> 1900s).
- `placeholders.go` (new): these export variants also tend to omit the LRO
  marker (U+200E) WhatsApp otherwise uses to mark its own placeholder text
  (deleted messages, omitted media, the edited-message note) for automatic
  removal. Since the marker isn't present, these are matched by their literal
  (German) text instead, mirroring how the LRO-tagged variants already work:
  media-omitted and deleted-message placeholders are dropped entirely, and
  the edited-message marker is stripped from the end of the real message text
  rather than dropping the whole message.

## Testing

- New unit tests for the 2-digit-year date parsing (`splitter_test.go`) and
  time conversion, including Go's year-pivot behavior.
- New fixture + end-to-end test (`testdata/fixtures-de/`) covering the
  2-digit year format plus all three placeholder cases.
- All existing tests still pass unchanged (no regressions to the existing
  4-digit-year / LRO-based export format).
- Verified against my own real ~300-message German export, both via
  automated test and by importing it into a live Timelinize instance.