### PR TITLE
Dockerfile: pin libvips to v8.18.4 to fix broken build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN rm -rf /var/lib/apt/lists/*
 
 # Build latest libvips from source with caching
 RUN --mount=type=cache,target=/tmp/libvips-cache \
-    git clone --depth 1 https://github.com/libvips/libvips.git /tmp/libvips && \
+    git clone --depth 1 --branch v8.18.4 https://github.com/libvips/libvips.git /tmp/libvips && \
     cd /tmp/libvips && \
     meson setup build --buildtype=release --wrap-mode=forcefallback --backend=ninja -Dprefix=/usr -Dlibdir=/usr/lib && \
     ninja -C build && \


### PR DESCRIPTION
Cloning HEAD of libvips fails during meson setup due to a missing VipsForeignPdfPageBox type. Pinning to the latest stable release fixes the build and makes it reproducible.

Steps to reproduce
1. `podman build --no-cache -t timelinize . 2>&1 | tail -20`
```
  meson.build:107:39: ERROR: Could not get an internal variable and no default
  provided for <InternalDependency gmodule-no-export-2.0: True>

  A full log can be found at /tmp/libvips/build/meson-logs/meson-log.txt
  Error: building at STEP "RUN --mount=type=cache,target=/tmp/libvips-cache git clone
  --depth 1 https://github.com/libvips/libvips.git /tmp/libvips &&     cd /tmp/libvips
   &&     meson setup build --buildtype=release --wrap-mode=forcefallback
  --backend=ninja -Dprefix=/usr -Dlibdir=/usr/lib &&     ninja -C build &&     ninja
  -C build install &&     rm -rf /tmp/libvips &&     ldconfig": while running runtime:
   exit status 1
```

## Assistance Disclosure
Claude helped identify the issue and generated the code. I verified it is correct.